### PR TITLE
Fix particle culling causing crash

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
@@ -39,6 +39,9 @@ public class OptifineFixer {
 		//net/minecraft/client/particle/ParticleManager
 		skipClass("class_702"); //Skip a seemingly pointless patch to register particles by register name rather than ID
 
+		//net/minecraft/client/render/WorldRenderer
+		registerFix("class_761", new WorldRendererFix());
+
 		//net/minecraft/client/render/model/json/ModelOverrideList
 		registerFix("class_806", new ModelOverrideListFix());
 

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/WorldRendererFix.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/WorldRendererFix.java
@@ -1,0 +1,53 @@
+package me.modmuss50.optifabric.patcher.fixes;
+
+import me.modmuss50.optifabric.util.RemappingUtils;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class WorldRendererFix implements ClassFixer {
+
+    @Override
+    public void fix(ClassNode classNode, ClassNode old) {
+        for (MethodNode methodNode : classNode.methods) {
+            for (int i = 0; i < methodNode.instructions.size(); i++) {
+                AbstractInsnNode insnNode = methodNode.instructions.get(i);
+
+                if (insnNode instanceof MethodInsnNode) {
+                    MethodInsnNode methodInsnNode = (MethodInsnNode) insnNode;
+
+                    if (methodInsnNode.getOpcode() == Opcodes.INVOKEVIRTUAL) {
+                        if ("renderParticles".equals(methodInsnNode.name)) {
+							/* For reference:
+
+							class_4587 - net/minecraft/client/util/math/MatrixStack
+							class_4597$class_4598 - net/minecraft/client/render/VertexConsumerProvider.Immediate
+							class_765 - net/minecraft/client/render/LightmapTextureManager
+							class_4184 - net/minecraft/client/render/Camera
+							 */
+
+                            String desc = "(Lnet/minecraft/class_4587;"
+                                    + "Lnet/minecraft/class_4597$class_4598;"
+                                    + "Lnet/minecraft/class_765;"
+                                    + "Lnet/minecraft/class_4184;"
+                                    + "F)V";
+                            String name = RemappingUtils.getMethodName("class_702", "method_3049", desc);
+
+                            System.out.printf("Replacement `renderParticles` call:  %s.%s%n", name, desc);
+
+                            //Replaces the method call with the vanilla one, this calls down to the same method just without extra data for particle culling
+                            methodInsnNode.name = name;
+                            methodInsnNode.desc = RemappingUtils.mapMethodDescriptor(desc);
+
+                            //Remove the old extra method call
+                            methodNode.instructions.remove(methodNode.instructions.get(i - 1));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Simple fix with no further issues yet.

**Downside:** Doesn't take advantage of Particle culling. Maybe I will add this later on by removing the skip of class 702, For now, this is a fully working update for 1.16.3.